### PR TITLE
Make commit message configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ An automatic Docker builder is under development. Coming soon!
 - `release-tags` optional  
     The names to tag the compiled file commit.
 
+- `commit-message` optional  
+    The commit message for the compiled.
+
 ## Contribution
 PRs are accepted.
 

--- a/action.yml
+++ b/action.yml
@@ -6,12 +6,18 @@ branding:
   color: white
 
 inputs:
-  release-branch:
+  push-branch:
     description: The name of branch to push compiled file.
     required: true
+
   release-tags:
     description: The names to tag the compiled file commit.
     required: false
+
+  commit-message:
+    description: The commit message for the compiled.
+    required: true
+    default: '[auto]'
 
 runs:
   using: node12

--- a/index.js
+++ b/index.js
@@ -157,11 +157,11 @@ const clean = (...excludePaths) => {
   core.endGroup()
 }
 
-const push = async (branch, tags) => {
+const push = async (branch, tags, message) => {
   core.startGroup('git')
   await exec.exec('git checkout -b ', [branch])
   await exec.exec('git add .')
-  await exec.exec('git commit -m [auto]')
+  await exec.exec('git commit -m', message)
   console.log(tags)
   if (tags.length > 0) {
     await exec.exec('git tag', tags)
@@ -181,12 +181,14 @@ const main = async () => {
   const tags = typeof core.getInput('release-tags') === 'string' && core.getInput('release-tags').length > 0
     ? core.getInput('release-tags').split(' ') : []
 
+  const commitMessage = core.getInput('commit-message', { required: true })
+
   await configureGit()
   await installNcc()
   await installDependencies()
   const builtFiles = await buildAction()
   clean(builtFiles)
-  await push(releaseBranch, tags)
+  await push(releaseBranch, tags, commitMessage)
 }
 
 main().catch(e => {


### PR DESCRIPTION
Added `commit-message` input.

---

If it is configured as follows,
https://github.com/satackey/push-prebuilt-action/blob/2be72bc4dd358e798ebbc71ba23d58270cf331e1/.github/workflows/release.yml#L32-L34

this will generate a commit like this.
64ed7e9c1209baadca6e5d7bd69c81c0fa50033c